### PR TITLE
109 fix user api test without role

### DIFF
--- a/src/api/api_tests/test_api_users.py
+++ b/src/api/api_tests/test_api_users.py
@@ -42,6 +42,16 @@ class CustomUserAPITest(APITestCase):
             "role": cls.role_1.id
         }
 
+    @classmethod
+    def tearDownClass(cls):
+        super().tearDownClass()
+        del cls.url
+        del cls.api_client
+        cls.role_1.delete()
+        cls.role_2.delete()
+        del cls.unique_user
+        del cls.user_data
+
     def test_post_user(self):
         response = self.api_client.post(
             self.url, self.user_data)
@@ -114,3 +124,14 @@ class CustomUserAPITest(APITestCase):
         self.assertEqual(
             failed_response.status_code,
             status.HTTP_400_BAD_REQUEST)
+
+    def test_user_without_or_invalid_role(self):
+        invalid_role_data = self.user_data.copy()
+        invalid_role_data["role"] = ""
+        response = self.api_client.post(self.url, invalid_role_data)
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertEqual(User.objects.count(), 0)
+        invalid_role_data["role"] = "fsdfsdf"
+        response = self.api_client.post(self.url, invalid_role_data)
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertEqual(User.objects.count(), 0)

--- a/src/users/users_tests/test_models.py
+++ b/src/users/users_tests/test_models.py
@@ -22,6 +22,12 @@ class CustomUserManagerTests(TestCase):
         )
         return super().setUpClass()
 
+    @classmethod
+    def tearDownClass(cls):
+        super().tearDownClass()
+        cls.user.delete()
+        cls.admin_user.delete()
+
     def test_create_user(self):
         self.assertEqual(self.user.email, "user@example.ru")
         self.assertTrue(self.user.check_password("Fool123"))


### PR DESCRIPTION
Добавил проверку, что не возможно создать пользователя без роли или не верными данными. Добавил tearDownClass для очистки после теста